### PR TITLE
Make reST/restructuredtext.py compatible with python 2.7

### DIFF
--- a/reST/restructuredtext.py
+++ b/reST/restructuredtext.py
@@ -28,7 +28,7 @@ class RestructuredtextHtmlPanel(Gtk.ScrolledWindow):
     """
     MIME_TYPE = 'text/html'
     ENCODING = 'UTF-8'
-    TEMPLATE = """<!DOCTYPE html>
+    TEMPLATE = u"""<!DOCTYPE html>
     <html>
     <head>
         <style type="text/css">
@@ -71,7 +71,8 @@ class RestructuredtextHtmlPanel(Gtk.ScrolledWindow):
 
             text = doc.get_text(start, end, False)
             html = publish_parts(text, writer_name='html')['html_body']
-            base_uri = parent_window.get_active_document().get_location().get_uri()
+            base_uri = parent_window.get_active_document().\
+                get_location().get_uri()
 
         self.view.load_string(self.TEMPLATE.format(
             body=html, css=self.styles


### PR DESCRIPTION
With this commit (and the obvious change in `reST.plugin`) I get this plugin working with python 2.7 (there is no `python3` for RHEL-7).