### PR TITLE
Settings working

### DIFF
--- a/reST/__init__.py
+++ b/reST/__init__.py
@@ -111,6 +111,8 @@ class ReStructuredTextPlugin(GObject.Object, Gedit.WindowActivatable,
 
         self.display_panel = new_panel
         self.add_container_to_panel()
+        self.display_panel.set_visible(True)
+        self.display_panel.set_visible_child(self.html_container)
         self.do_update_state()
 
 # ex:et:ts=4:

--- a/reST/__init__.py
+++ b/reST/__init__.py
@@ -17,6 +17,7 @@ __init__.py - HTML preview for reStructuredText (.rst) plugin
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
 
+import logging
 import gi
 
 gi.require_version('Gtk', '3.0')
@@ -31,7 +32,11 @@ from .config import RestructuredtextConfigWidget, Settings
 from .restructuredtext import RestructuredtextHtmlContainer
 
 
-class ReStructuredTextPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.Configurable):
+log = logging.getLogger(__name__)
+
+
+class ReStructuredTextPlugin(GObject.Object, Gedit.WindowActivatable,
+                             PeasGtk.Configurable):
     __gtype_name__ = "ReStructuredTextPlugin"
 
     window = GObject.Property(type=Gedit.Window)
@@ -55,10 +60,12 @@ class ReStructuredTextPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.Co
         self.display_panel.show_now()
 
         try:
-            self.display_panel.add_titled(self.html_container, panel_name, panel_title)
+            self.display_panel.add_titled(self.html_container, panel_name,
+                                          panel_title)
         except AttributeError as err:
-            print('Falling back to old implementation. Reason: %s' % err)
-            self.display_panel.add_item(self.html_container, panel_name, panel_title)
+            log.warning('Falling back to old implementation. Reason: %s', err)
+            self.display_panel.add_item(self.html_container, panel_name,
+                                        panel_title)
         self.handler_id = self.display_panel.connect(
             "notify::visible-child", self.handle_panel_change)
 

--- a/reST/config.py
+++ b/reST/config.py
@@ -84,12 +84,13 @@ class RestructuredtextConfigWidget:
     Preferences dialog factory.
     """
 
-    def __init__(self, parent):
-        self._parent = parent
-        datadir = parent.plugin_info.get_data_dir()
+    def __init__(self, plugin_instance):
+        self._plugin_instance = plugin_instance
+        datadir = plugin_instance.plugin_info.get_data_dir()
         self._ui_path = os.path.join(datadir, 'config.ui')
         self._ui = Gtk.Builder()
         self._settings = Settings.get()
+        self._last_choice = None
 
     def configure_widget(self):
         self._ui.add_from_file(self._ui_path)
@@ -100,15 +101,20 @@ class RestructuredtextConfigWidget:
             radiobutton = self._ui.get_object(panel_id)
             radiobutton.connect('toggled', self.on_button_toggled, panel_id)
             radiobutton.set_active(configured_panel == index)
+            if configured_panel == index:
+                self._last_choice = index
 
         widget = self._ui.get_object('restructuredtext_preferences')
         return widget
 
     def on_button_toggled(self, radiobutton, panel_id):
         if radiobutton.get_active():
-            # self._parent.do_deactivate()
             index = REST_PREVIEW_PANELS.index(panel_id)
             self._settings.set_panel_index(index)
-            # self._parent.do_activate()
+            # preview container has been moved to the new panel at this point
+            if self._last_choice is not None and self._last_choice != index:
+                self._plugin_instance.force_show_preview()
+                self._plugin_instance.do_update_state()
+            self._last_choice = index
 
 # ex:et:ts=4:

--- a/reST/restructuredtext.py
+++ b/reST/restructuredtext.py
@@ -114,7 +114,8 @@ class RestructuredtextHtmlContainer(Gtk.ScrolledWindow):
             self.view.hide()
 
     def preview_visible(self):
-        return self.panel.get_visible_child() == self
+        return (self.panel.is_visible() and
+                self.panel.get_visible_child() == self)
 
     def update_view(self):
         if self.state == State.EXIT:

--- a/reST/restructuredtext.py
+++ b/reST/restructuredtext.py
@@ -28,7 +28,7 @@ from os.path import abspath, dirname, join
 from gi.repository import GLib, Gtk, WebKit2
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
+log.setLevel(logging.INFO)
 
 
 class State(Enum):
@@ -93,6 +93,9 @@ class RestructuredtextHtmlContainer(Gtk.ScrolledWindow):
         self.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.set_shadow_type(Gtk.ShadowType.NONE)
         self.viewinit = False
+
+    def set_panel(self, new_panel):
+        self.panel = new_panel
 
     def show_view(self):
         if not self.viewinit:


### PR DESCRIPTION
Hi Peter, I managed to get the settings notification and moving the panel working. I also added some code to force the preview to show if the preference is changed.

One thing I noticed is that Glib instantiates two separate instances if the plugin class also extends `PeasGtk.Configurable`, one as the plugin and one for the configuration panel. As a result the `parent` parameter to the `RestructuredtextConfigWidget` constructor was an uninitialized plugin instance. I split the `PeasGtk.Configurable` to a separate class to avoid this confusion.

Note: this PR sits on top of the changes in #19