### PR TITLE
Fix startup behavior

### DIFF
--- a/reST/__init__.py
+++ b/reST/__init__.py
@@ -61,8 +61,7 @@ class ReStructuredTextPlugin(GObject.Object, Gedit.WindowActivatable):
         self.html_container = RestructuredtextHtmlContainer(
             self.window, self.display_panel)
         self.add_container_to_panel()
-        self.html_container.show_now()
-        self.display_panel.show_now()
+        self.html_container.show()
         self.html_container.update_view()
 
         Settings.get().connect(self.on_panel_setting_change)
@@ -91,10 +90,12 @@ class ReStructuredTextPlugin(GObject.Object, Gedit.WindowActivatable):
             self.display_panel.add_item(self.html_container, panel_name,
                                         panel_title)
         self.html_container.set_panel(self.display_panel)
+        self.display_panel.connect("notify::visible", self.do_update_state)
         self.display_panel.connect("notify::visible-child",
                                    self.do_update_state)
 
     def remove_container_from_panel(self):
+        self.display_panel.disconnect_by_func(self.do_update_state)
         self.display_panel.disconnect_by_func(self.do_update_state)
         self.display_panel.remove(self.html_container)
 


### PR DESCRIPTION
> > I also added some code to force the preview to show if the preference is changed.
> 
> @JanKanis This seems to have some side effects now. When you disable the view panel (e.g. _View_ ➜ _Bottom Panel_) gedit will happily reopen the panel upon the next startup. Even without a document. I'm not sure if this is desired.
> 
> Can you reproduce this, too? Should we make the panel open only if there is a `.rst` file being loaded or similar?

This appears to fix the issue. It wasn't the preferences forcing the preview to show, but the `self.display_panel.show_now()`.
I don't think it should modify panel visibility without the user asking for it.