### PR TITLE
Fix breakage in gedit 3.36

### DIFF
--- a/reST/restructuredtext.py
+++ b/reST/restructuredtext.py
@@ -202,7 +202,8 @@ class RestructuredtextHtmlContainer(Gtk.ScrolledWindow):
 
         base_uri = ''
         if self.state == State.REST:
-            location = self.parent_window.get_active_document().get_location()
+            location = self.parent_window.get_active_document()\
+                .get_file().get_location()
             base_uri = location.get_uri() if location else ''
 
         script = ''


### PR DESCRIPTION
After updating to Ubuntu 20.04, the plugin broke.

As I now no longer have the old gedit installed I'm not able to test easily if this change also works on older gedits. Are you able to check that?